### PR TITLE
drivers/md/dm-crypt bugfix: support recent vold

### DIFF
--- a/drivers/md/dm-crypt.c
+++ b/drivers/md/dm-crypt.c
@@ -1587,7 +1587,7 @@ static int crypt_ctr(struct dm_target *ti, unsigned int argc, char **argv)
 	unsigned long long tmpll;
 	int ret;
 
-	if (argc != 5) {
+	if (argc < 5) {
 		ti->error = "Not enough arguments";
 		return -EINVAL;
 	}


### PR DESCRIPTION
In a recent commit (https://github.com/CyanogenMod/android_system_vold/commit/db5e026058927347ccff8f170c8f160b28cbc75b) the number of arguments passed to dm-crypt by vold/crypt.c was increased by one, with the introduction of a "discard" option. As a result, their smdk4412 kernel was patched (https://github.com/CyanogenMod/android_kernel_samsung_smdk4412/commit/c538f742a9e67eca1ccdc801e8173a7e4ce30644) to allow more than 5 arguments and to support the discard option.

This PR simply adds the support for more than 5 arguments, but will ignore them. I see that on my i9300 there is no support for discard, so I don't need it, but maybe backporting the whole patch would be better. Unfortunately, I don't have the qualifications to backport it correctly
