### PR TITLE
bcmdhd: Enable WiFi MAC address changing

### DIFF
--- a/drivers/net/wireless/bcmdhd/dhd_sec_feature.h
+++ b/drivers/net/wireless/bcmdhd/dhd_sec_feature.h
@@ -217,3 +217,5 @@
 #define WRITE_WLANINFO
 
 #endif /* _dhd_sec_feature_h_ */
+
+#define READ_MACADDR


### PR DESCRIPTION
Kernel needs to be patched to use that above function, This is the patch.

More info here: http://forum.xda-developers.com/showthread.php?t=1878506
